### PR TITLE
Main: print stack trace of uncaught exceptions

### DIFF
--- a/src/seedu/addressbook/Main.java
+++ b/src/seedu/addressbook/Main.java
@@ -1,7 +1,6 @@
 package seedu.addressbook;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 
 import javafx.stage.Stage;
 import seedu.addressbook.logic.Logic;
@@ -22,13 +21,6 @@ public class Main extends Application implements Stoppable{
     public void start(Stage primaryStage) throws Exception{
         gui = new Gui(new Logic(), VERSION);
         gui.start(primaryStage, this);
-    }
-
-    @Override
-    public void stop() throws Exception {
-        super.stop();
-        Platform.exit();
-        System.exit(0);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
When an uncaught exception occurs in the JavaFX application thread (such
as an exception thrown when start() runs), the following is printed and
the program exits:

```
Exception in Application start method
```

This is not very useful, as it does not provide the stack trace which
tells us where the exception was thrown.

This is because in the overriden stop() method, System.exit(0) is
called, which interferes with JavaFX's ability to provide a stack trace.
Remove that, and now we have a nice stack trace as well:

```
Exception in Application start method
java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.sun.javafx.application.LauncherImpl.launchApplicationWithArgs(LauncherImpl.java:389)
        at com.sun.javafx.application.LauncherImpl.launchApplication(LauncherImpl.java:328)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
etc...
```

At the same time, remove the call to Platform.exit() as well. The
javafx.application.Application[1] docs states that stop() will only be
called when the application is exiting anyway, so there's no point
calling Platform.exit() again.

[1] https://docs.oracle.com/javase/8/javafx/api/javafx/application/Application.html
