### PR TITLE
ui: display lastShownList in a TableView

### DIFF
--- a/src/seedu/addressbook/commands/AddCommand.java
+++ b/src/seedu/addressbook/commands/AddCommand.java
@@ -60,7 +60,7 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            addressBook.addPerson(toAdd);
+            addressBookSession.addPerson(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (UniquePersonList.DuplicatePersonException dpe) {
             return new CommandResult(MESSAGE_DUPLICATE_PERSON);

--- a/src/seedu/addressbook/commands/ClearCommand.java
+++ b/src/seedu/addressbook/commands/ClearCommand.java
@@ -16,7 +16,7 @@ public class ClearCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        addressBook.clear();
+        addressBookSession.clear();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -1,7 +1,6 @@
 package seedu.addressbook.commands;
 
 import seedu.addressbook.common.Messages;
-import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.logic.AddressBookSession;
 
@@ -11,8 +10,6 @@ import java.util.List;
  * Represents an executable command.
  */
 public abstract class Command {
-    protected AddressBook addressBook;
-    protected List<? extends ReadOnlyPerson> relevantPersons;
     protected AddressBookSession addressBookSession;
 
     protected Command() {
@@ -38,7 +35,5 @@ public abstract class Command {
      */
     public void setData(AddressBookSession addressBookSession) {
         this.addressBookSession = addressBookSession;
-        this.addressBook = addressBookSession.getAddressBook();
-        this.relevantPersons = addressBookSession.getLastShownList();
     }
 }

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -6,22 +6,12 @@ import seedu.addressbook.data.person.ReadOnlyPerson;
 
 import java.util.List;
 
-import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
-
 /**
  * Represents an executable command.
  */
 public abstract class Command {
     protected AddressBook addressBook;
     protected List<? extends ReadOnlyPerson> relevantPersons;
-    private int targetIndex = -1;
-
-    /**
-     * @param targetIndex last visible listing index of the target person
-     */
-    public Command(int targetIndex) {
-        this.setTargetIndex(targetIndex);
-    }
 
     protected Command() {
     }
@@ -47,22 +37,5 @@ public abstract class Command {
     public void setData(AddressBook addressBook, List<? extends ReadOnlyPerson> relevantPersons) {
         this.addressBook = addressBook;
         this.relevantPersons = relevantPersons;
-    }
-
-    /**
-     * Extracts the the target person in the last shown list from the given arguments.
-     *
-     * @throws IndexOutOfBoundsException if the target index is out of bounds of the last viewed listing
-     */
-    protected ReadOnlyPerson getTargetPerson() throws IndexOutOfBoundsException {
-        return relevantPersons.get(getTargetIndex() - DISPLAYED_INDEX_OFFSET);
-    }
-
-    public int getTargetIndex() {
-        return targetIndex;
-    }
-
-    public void setTargetIndex(int targetIndex) {
-        this.targetIndex = targetIndex;
     }
 }

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -3,6 +3,7 @@ package seedu.addressbook.commands;
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.logic.AddressBookSession;
 
 import java.util.List;
 
@@ -12,6 +13,7 @@ import java.util.List;
 public abstract class Command {
     protected AddressBook addressBook;
     protected List<? extends ReadOnlyPerson> relevantPersons;
+    protected AddressBookSession addressBookSession;
 
     protected Command() {
     }
@@ -34,8 +36,9 @@ public abstract class Command {
     /**
      * Supplies the data the command will operate on.
      */
-    public void setData(AddressBook addressBook, List<? extends ReadOnlyPerson> relevantPersons) {
-        this.addressBook = addressBook;
-        this.relevantPersons = relevantPersons;
+    public void setData(AddressBookSession addressBookSession) {
+        this.addressBookSession = addressBookSession;
+        this.addressBook = addressBookSession.getAddressBook();
+        this.relevantPersons = addressBookSession.getLastShownList();
     }
 }

--- a/src/seedu/addressbook/commands/DeleteCommand.java
+++ b/src/seedu/addressbook/commands/DeleteCommand.java
@@ -12,7 +12,7 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n"
             + "Deletes the person identified by the index number used in the last person listing.\n\t"
             + "Parameters: INDEX\n\t"
             + "Example: " + COMMAND_WORD + " 1";

--- a/src/seedu/addressbook/commands/DeleteCommand.java
+++ b/src/seedu/addressbook/commands/DeleteCommand.java
@@ -4,6 +4,7 @@ import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 
+import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
 
 /**
  * Deletes a person identified using it's last displayed index from the address book.
@@ -19,16 +20,16 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
+    private final int targetIndex;
 
-    public DeleteCommand(int targetVisibleIndex) {
-        super(targetVisibleIndex);
+    public DeleteCommand(int targetIndex) {
+        this.targetIndex = targetIndex;
     }
-
 
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = getTargetPerson();
+            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
             addressBook.removePerson(target);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, target));
 
@@ -37,6 +38,10 @@ public class DeleteCommand extends Command {
         } catch (PersonNotFoundException pnfe) {
             return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
         }
+    }
+
+    public int getTargetIndex() {
+        return targetIndex;
     }
 
 }

--- a/src/seedu/addressbook/commands/DeleteCommand.java
+++ b/src/seedu/addressbook/commands/DeleteCommand.java
@@ -28,7 +28,7 @@ public class DeleteCommand extends Command {
     public CommandResult execute() {
         try {
             final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
-            addressBook.removePerson(target);
+            addressBookSession.removePerson(targetIndex);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, target));
 
         } catch (IndexOutOfBoundsException ie) {

--- a/src/seedu/addressbook/commands/DeleteCommand.java
+++ b/src/seedu/addressbook/commands/DeleteCommand.java
@@ -4,8 +4,6 @@ import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 
-import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
-
 /**
  * Deletes a person identified using it's last displayed index from the address book.
  */
@@ -29,7 +27,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
+            final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
             addressBook.removePerson(target);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, target));
 

--- a/src/seedu/addressbook/commands/FindCommand.java
+++ b/src/seedu/addressbook/commands/FindCommand.java
@@ -32,25 +32,11 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        final List<ReadOnlyPerson> personsFound = getPersonsWithNameContainingAnyKeyword(keywords);
+        addressBookSession.setFilter(person -> {
+            final Set<String> wordsInName = new HashSet<>(person.getName().getWordsInName());
+            return !Collections.disjoint(wordsInName,  keywords);
+        });
+        final List<ReadOnlyPerson> personsFound = addressBookSession.getLastShownList();
         return new CommandResult(getMessageForPersonListShownSummary(personsFound), personsFound);
     }
-
-    /**
-     * Retrieve all persons in the address book whose names contain some of the specified keywords.
-     *
-     * @param keywords for searching
-     * @return list of persons found
-     */
-    private List<ReadOnlyPerson> getPersonsWithNameContainingAnyKeyword(Set<String> keywords) {
-        final List<ReadOnlyPerson> matchedPersons = new ArrayList<>();
-        for (ReadOnlyPerson person : addressBook.getAllPersons()) {
-            final Set<String> wordsInName = new HashSet<>(person.getName().getWordsInName());
-            if (!Collections.disjoint(wordsInName, keywords)) {
-                matchedPersons.add(person);
-            }
-        }
-        return matchedPersons;
-    }
-
 }

--- a/src/seedu/addressbook/commands/ListCommand.java
+++ b/src/seedu/addressbook/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n"
             + "Displays all persons in the address book as a list with index numbers.\n\t"
             + "Example: " + COMMAND_WORD;
 

--- a/src/seedu/addressbook/commands/ListCommand.java
+++ b/src/seedu/addressbook/commands/ListCommand.java
@@ -19,7 +19,8 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        List<ReadOnlyPerson> allPersons = addressBook.getAllPersons().immutableListView();
+        addressBookSession.setFilter(null);
+        List<ReadOnlyPerson> allPersons = addressBookSession.getLastShownList();
         return new CommandResult(getMessageForPersonListShownSummary(allPersons), allPersons);
     }
 }

--- a/src/seedu/addressbook/commands/ViewAllCommand.java
+++ b/src/seedu/addressbook/commands/ViewAllCommand.java
@@ -28,7 +28,7 @@ public class ViewAllCommand extends Command {
     public CommandResult execute() {
         try {
             final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
-            if (!addressBook.containsPerson(target)) {
+            if (!addressBookSession.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }
             return new CommandResult(String.format(MESSAGE_VIEW_PERSON_DETAILS, target.getAsTextShowAll()));

--- a/src/seedu/addressbook/commands/ViewAllCommand.java
+++ b/src/seedu/addressbook/commands/ViewAllCommand.java
@@ -3,8 +3,6 @@ package seedu.addressbook.commands;
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 
-import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
-
 /**
  * Shows all details of the person identified using the last displayed index.
  * Private contact details are shown.
@@ -29,7 +27,7 @@ public class ViewAllCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
+            final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
             if (!addressBook.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }

--- a/src/seedu/addressbook/commands/ViewAllCommand.java
+++ b/src/seedu/addressbook/commands/ViewAllCommand.java
@@ -3,6 +3,7 @@ package seedu.addressbook.commands;
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 
+import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
 
 /**
  * Shows all details of the person identified using the last displayed index.
@@ -19,16 +20,16 @@ public class ViewAllCommand extends Command {
 
     public static final String MESSAGE_VIEW_PERSON_DETAILS = "Viewing person: %1$s";
 
+    private final int targetIndex;
 
-    public ViewAllCommand(int targetVisibleIndex) {
-        super(targetVisibleIndex);
+    public ViewAllCommand(int targetIndex) {
+        this.targetIndex = targetIndex;
     }
-
 
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = getTargetPerson();
+            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
             if (!addressBook.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }
@@ -36,5 +37,9 @@ public class ViewAllCommand extends Command {
         } catch (IndexOutOfBoundsException ie) {
             return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+    }
+
+    public int getTargetIndex() {
+        return targetIndex;
     }
 }

--- a/src/seedu/addressbook/commands/ViewCommand.java
+++ b/src/seedu/addressbook/commands/ViewCommand.java
@@ -3,8 +3,6 @@ package seedu.addressbook.commands;
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 
-import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
-
 /**
  * Shows details of the person identified using the last displayed index.
  * Private contact details are not shown.
@@ -29,7 +27,7 @@ public class ViewCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
+            final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
             if (!addressBook.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }

--- a/src/seedu/addressbook/commands/ViewCommand.java
+++ b/src/seedu/addressbook/commands/ViewCommand.java
@@ -28,7 +28,7 @@ public class ViewCommand extends Command {
     public CommandResult execute() {
         try {
             final ReadOnlyPerson target = addressBookSession.getPerson(targetIndex);
-            if (!addressBook.containsPerson(target)) {
+            if (!addressBookSession.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }
             return new CommandResult(String.format(MESSAGE_VIEW_PERSON_DETAILS, target.getAsTextHidePrivate()));

--- a/src/seedu/addressbook/commands/ViewCommand.java
+++ b/src/seedu/addressbook/commands/ViewCommand.java
@@ -3,6 +3,7 @@ package seedu.addressbook.commands;
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 
+import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
 
 /**
  * Shows details of the person identified using the last displayed index.
@@ -19,16 +20,16 @@ public class ViewCommand extends Command {
 
     public static final String MESSAGE_VIEW_PERSON_DETAILS = "Viewing person: %1$s";
 
+    private final int targetIndex;
 
-    public ViewCommand(int targetVisibleIndex) {
-        super(targetVisibleIndex);
+    public ViewCommand(int targetIndex) {
+        this.targetIndex = targetIndex;
     }
-
 
     @Override
     public CommandResult execute() {
         try {
-            final ReadOnlyPerson target = getTargetPerson();
+            final ReadOnlyPerson target = relevantPersons.get(targetIndex - DISPLAYED_INDEX_OFFSET);
             if (!addressBook.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }
@@ -36,6 +37,10 @@ public class ViewCommand extends Command {
         } catch (IndexOutOfBoundsException ie) {
             return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+    }
+
+    public int getTargetIndex() {
+        return targetIndex;
     }
 
 }

--- a/src/seedu/addressbook/data/person/ReadOnlyPerson.java
+++ b/src/seedu/addressbook/data/person/ReadOnlyPerson.java
@@ -1,6 +1,5 @@
 package seedu.addressbook.data.person;
 
-import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
 
 /**
@@ -54,10 +53,7 @@ public interface ReadOnlyPerson {
             builder.append(detailIsPrivate);
         }
         builder.append(getAddress())
-                .append(" Tags: ");
-        for (Tag tag : getTags()) {
-            builder.append(tag);
-        }
+                .append(" Tags: ").append(getTags());
         return builder.toString();
     }
 
@@ -76,10 +72,7 @@ public interface ReadOnlyPerson {
         if (!getAddress().isPrivate()) {
             builder.append(" Address: ").append(getAddress());
         }
-        builder.append(" Tags: ");
-        for (Tag tag : getTags()) {
-            builder.append(tag);
-        }
+        builder.append(" Tags: ").append(getTags());
         return builder.toString();
     }
 }

--- a/src/seedu/addressbook/data/tag/UniqueTagList.java
+++ b/src/seedu/addressbook/data/tag/UniqueTagList.java
@@ -164,4 +164,13 @@ public class UniqueTagList implements Iterable<Tag> {
     public int hashCode() {
         return internalList.hashCode();
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Tag tag : this) {
+            sb.append(tag);
+        }
+        return sb.toString();
+    }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -3,6 +3,7 @@ package seedu.addressbook.logic;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.Person;
@@ -21,6 +22,7 @@ import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
 public class AddressBookSession {
     private final AddressBook addressBook;
     private List<ReadOnlyPerson> lastShownList;
+    private Predicate<ReadOnlyPerson> filter;
 
     public AddressBookSession(AddressBook addressBook) {
         this.addressBook = addressBook;
@@ -39,6 +41,20 @@ public class AddressBookSession {
         // lastShownList may actually just be a view to this.lastShownList. To make sure there's no
         // clobbering of data, make a defensive copy.
         this.lastShownList = new ArrayList<>(lastShownList);
+    }
+
+    public final Predicate<ReadOnlyPerson> getFilter() {
+        return filter;
+    }
+
+    public void setFilter(Predicate<ReadOnlyPerson> filter) {
+        this.filter = filter;
+        lastShownList.clear();
+        for (Person person : addressBook.getAllPersons()) {
+            if (filter == null || filter.test(person)) {
+                lastShownList.add(person);
+            }
+        }
     }
 
     public void addPerson(Person toAdd) throws DuplicatePersonException {

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -8,6 +8,7 @@ import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
+import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 
 import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
 
@@ -46,5 +47,10 @@ public class AddressBookSession {
 
     public ReadOnlyPerson getPerson(int index) throws IndexOutOfBoundsException {
         return lastShownList.get(index - DISPLAYED_INDEX_OFFSET);
+    }
+
+    public void removePerson(int index) throws IndexOutOfBoundsException, PersonNotFoundException {
+        final ReadOnlyPerson target = getPerson(index);
+        addressBook.removePerson(target);
     }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -1,10 +1,11 @@
 package seedu.addressbook.logic;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
@@ -21,26 +22,28 @@ import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
  */
 public class AddressBookSession {
     private final AddressBook addressBook;
-    private List<ReadOnlyPerson> lastShownList;
+    private ObservableList<ReadOnlyPerson> lastShownList;
     private Predicate<ReadOnlyPerson> filter;
 
     public AddressBookSession(AddressBook addressBook) {
         this.addressBook = addressBook;
-        this.lastShownList = new ArrayList<>();
+        this.lastShownList = FXCollections.observableArrayList();
     }
 
     public final AddressBook getAddressBook() {
         return addressBook;
     }
 
-    public final List<ReadOnlyPerson> getLastShownList() {
-        return Collections.unmodifiableList(lastShownList);
+    public final ObservableList<ReadOnlyPerson> getLastShownList() {
+        return FXCollections.unmodifiableObservableList(lastShownList);
     }
 
     void setLastShownList(List<? extends ReadOnlyPerson> lastShownList) {
         // lastShownList may actually just be a view to this.lastShownList. To make sure there's no
         // clobbering of data, make a defensive copy.
-        this.lastShownList = new ArrayList<>(lastShownList);
+        final List<ReadOnlyPerson> newLastShownList = new ArrayList<>(lastShownList);
+        this.lastShownList.clear();
+        this.lastShownList.addAll(newLastShownList);
     }
 
     public final Predicate<ReadOnlyPerson> getFilter() {

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -74,6 +74,7 @@ public class AddressBookSession {
     public void removePerson(int index) throws IndexOutOfBoundsException, PersonNotFoundException {
         final ReadOnlyPerson target = getPerson(index);
         addressBook.removePerson(target);
+        lastShownList.remove(index - DISPLAYED_INDEX_OFFSET);
     }
 
     public boolean containsPerson(ReadOnlyPerson key) {

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -1,0 +1,39 @@
+package seedu.addressbook.logic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import seedu.addressbook.data.AddressBook;
+import seedu.addressbook.data.person.Person;
+import seedu.addressbook.data.person.ReadOnlyPerson;
+
+/**
+ * Represents the user's view of the address book.
+ *
+ * In particular, it implements the concept of a "last shown list", which is a list that contains a subset of
+ * the address book's persons. This list can be filtered and sorted independently of the address book.
+ */
+public class AddressBookSession {
+    private final AddressBook addressBook;
+    private List<ReadOnlyPerson> lastShownList;
+
+    public AddressBookSession(AddressBook addressBook) {
+        this.addressBook = addressBook;
+        this.lastShownList = new ArrayList<>();
+    }
+
+    public final AddressBook getAddressBook() {
+        return addressBook;
+    }
+
+    public final List<ReadOnlyPerson> getLastShownList() {
+        return Collections.unmodifiableList(lastShownList);
+    }
+
+    void setLastShownList(List<? extends ReadOnlyPerson> lastShownList) {
+        // lastShownList may actually just be a view to this.lastShownList. To make sure there's no
+        // clobbering of data, make a defensive copy.
+        this.lastShownList = new ArrayList<>(lastShownList);
+    }
+}

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -9,6 +9,8 @@ import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 
+import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
+
 /**
  * Represents the user's view of the address book.
  *
@@ -40,5 +42,9 @@ public class AddressBookSession {
 
     public void addPerson(Person toAdd) throws DuplicatePersonException {
         addressBook.addPerson(toAdd);
+    }
+
+    public ReadOnlyPerson getPerson(int index) throws IndexOutOfBoundsException {
+        return lastShownList.get(index - DISPLAYED_INDEX_OFFSET);
     }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -53,4 +53,8 @@ public class AddressBookSession {
         final ReadOnlyPerson target = getPerson(index);
         addressBook.removePerson(target);
     }
+
+    public boolean containsPerson(ReadOnlyPerson key) {
+        return addressBook.containsPerson(key);
+    }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -62,6 +62,9 @@ public class AddressBookSession {
 
     public void addPerson(Person toAdd) throws DuplicatePersonException {
         addressBook.addPerson(toAdd);
+        if (filter == null || filter.test(toAdd)) {
+            lastShownList.add(toAdd);
+        }
     }
 
     public ReadOnlyPerson getPerson(int index) throws IndexOutOfBoundsException {

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -7,6 +7,7 @@ import java.util.List;
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 
 /**
  * Represents the user's view of the address book.
@@ -35,5 +36,9 @@ public class AddressBookSession {
         // lastShownList may actually just be a view to this.lastShownList. To make sure there's no
         // clobbering of data, make a defensive copy.
         this.lastShownList = new ArrayList<>(lastShownList);
+    }
+
+    public void addPerson(Person toAdd) throws DuplicatePersonException {
+        addressBook.addPerson(toAdd);
     }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -79,5 +79,6 @@ public class AddressBookSession {
 
     public void clear() {
         addressBook.clear();
+        lastShownList.clear();
     }
 }

--- a/src/seedu/addressbook/logic/AddressBookSession.java
+++ b/src/seedu/addressbook/logic/AddressBookSession.java
@@ -57,4 +57,8 @@ public class AddressBookSession {
     public boolean containsPerson(ReadOnlyPerson key) {
         return addressBook.containsPerson(key);
     }
+
+    public void clear() {
+        addressBook.clear();
+    }
 }

--- a/src/seedu/addressbook/logic/Logic.java
+++ b/src/seedu/addressbook/logic/Logic.java
@@ -7,7 +7,6 @@ import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.parser.Parser;
 import seedu.addressbook.storage.StorageFile;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,10 +17,7 @@ public class Logic {
 
 
     private StorageFile storage;
-    private AddressBook addressBook;
-
-    /** The list of person shown to the user most recently.  */
-    private List<? extends ReadOnlyPerson> lastShownList = Collections.emptyList();
+    private AddressBookSession addressBookSession;
 
     public Logic() throws Exception{
         setStorage(initializeStorage());
@@ -38,7 +34,11 @@ public class Logic {
     }
 
     void setAddressBook(AddressBook addressBook){
-        this.addressBook = addressBook;
+        this.addressBookSession = new AddressBookSession(addressBook);
+    }
+
+    public final AddressBookSession getAddressBookSession() {
+        return addressBookSession;
     }
 
     /**
@@ -51,17 +51,6 @@ public class Logic {
 
     public String getStorageFilePath() {
         return storage.getPath();
-    }
-
-    /**
-     * Unmodifiable view of the current last shown list.
-     */
-    public List<ReadOnlyPerson> getLastShownList() {
-        return Collections.unmodifiableList(lastShownList);
-    }
-
-    protected void setLastShownList(List<? extends ReadOnlyPerson> newList) {
-        lastShownList = newList;
     }
 
     /**
@@ -83,9 +72,9 @@ public class Logic {
      * @throws Exception if there was any problem during command execution.
      */
     private CommandResult execute(Command command) throws Exception {
-        command.setData(addressBook, lastShownList);
+        command.setData(addressBookSession);
         CommandResult result = command.execute();
-        storage.save(addressBook);
+        storage.save(addressBookSession.getAddressBook());
         return result;
     }
 
@@ -93,7 +82,7 @@ public class Logic {
     private void recordResult(CommandResult result) {
         final Optional<List<? extends ReadOnlyPerson>> personList = result.getRelevantPersons();
         if (personList.isPresent()) {
-            lastShownList = personList.get();
+            addressBookSession.setLastShownList(personList.get());
         }
     }
 }

--- a/src/seedu/addressbook/logic/Logic.java
+++ b/src/seedu/addressbook/logic/Logic.java
@@ -3,12 +3,8 @@ package seedu.addressbook.logic;
 import seedu.addressbook.commands.Command;
 import seedu.addressbook.commands.CommandResult;
 import seedu.addressbook.data.AddressBook;
-import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.parser.Parser;
 import seedu.addressbook.storage.StorageFile;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents the main Logic of the AddressBook.
@@ -60,7 +56,6 @@ public class Logic {
     public CommandResult execute(String userCommandText) throws Exception {
         Command command = new Parser().parseCommand(userCommandText);
         CommandResult result = execute(command);
-        recordResult(result);
         return result;
     }
 
@@ -76,13 +71,5 @@ public class Logic {
         CommandResult result = command.execute();
         storage.save(addressBookSession.getAddressBook());
         return result;
-    }
-
-    /** Updates the {@link #lastShownList} if the result contains a list of Persons. */
-    private void recordResult(CommandResult result) {
-        final Optional<List<? extends ReadOnlyPerson>> personList = result.getRelevantPersons();
-        if (personList.isPresent()) {
-            addressBookSession.setLastShownList(personList.get());
-        }
     }
 }

--- a/src/seedu/addressbook/ui/MainWindow.java
+++ b/src/seedu/addressbook/ui/MainWindow.java
@@ -1,14 +1,23 @@
 package seedu.addressbook.ui;
 
 
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import seedu.addressbook.commands.ExitCommand;
 import seedu.addressbook.logic.Logic;
 import seedu.addressbook.commands.CommandResult;
+import seedu.addressbook.data.person.Address;
+import seedu.addressbook.data.person.Email;
+import seedu.addressbook.data.person.Name;
+import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.data.tag.UniqueTagList;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,8 +35,82 @@ public class MainWindow {
     public MainWindow(){
     }
 
+    public void initialize() {
+        personsIndexCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<ReadOnlyPerson>(col.getValue()));
+        // Cell factory for displaying the row index
+        personsIndexCol.setCellFactory(col -> {
+            return new TableCell<ReadOnlyPerson, ReadOnlyPerson>() {
+                @Override
+                protected void updateItem(ReadOnlyPerson item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (empty || item == null) {
+                        setText(null);
+                    } else {
+                        setText(Integer.toString(getTableRow().getIndex() + 1));
+                    }
+                }
+            };
+        });
+
+        personsNameCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<Name>(col.getValue().getName()));
+
+        personsPhoneCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<Phone>(col.getValue().getPhone()));
+        personsPhoneCol.setCellFactory(col -> {
+            return new TableCell<ReadOnlyPerson, Phone>() {
+                @Override
+                protected void updateItem(Phone item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (empty || item == null) {
+                        setText(null);
+                    } else if (item.isPrivate()) {
+                        setText("<private>");
+                    } else {
+                        setText(item.value);
+                    }
+                }
+            };
+        });
+
+        personsEmailCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<Email>(col.getValue().getEmail()));
+        personsEmailCol.setCellFactory(col -> {
+            return new TableCell<ReadOnlyPerson, Email>() {
+                @Override
+                protected void updateItem(Email item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (empty || item == null) {
+                        setText(null);
+                    } else if (item.isPrivate()) {
+                        setText("<private>");
+                    } else {
+                        setText(item.value);
+                    }
+                }
+            };
+        });
+
+        personsAddressCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<Address>(col.getValue().getAddress()));
+        personsAddressCol.setCellFactory(col -> {
+            return new TableCell<ReadOnlyPerson, Address>() {
+                @Override
+                protected void updateItem(Address item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (empty || item == null) {
+                        setText(null);
+                    } else if (item.isPrivate()) {
+                        setText("<private>");
+                    } else {
+                        setText(item.value);
+                    }
+                }
+            };
+        });
+
+        personsTagsCol.setCellValueFactory(col -> new ReadOnlyObjectWrapper<UniqueTagList>(col.getValue().getTags()));
+    }
+
     public void setLogic(Logic logic){
         this.logic = logic;
+        personsView.setItems(logic.getAddressBookSession().getLastShownList());
     }
 
     public void setMainApp(Stoppable mainApp){
@@ -40,6 +123,20 @@ public class MainWindow {
     @FXML
     private TextField commandInput;
 
+    @FXML
+    private TableView<ReadOnlyPerson> personsView;
+    @FXML
+    private TableColumn<ReadOnlyPerson, ReadOnlyPerson> personsIndexCol;
+    @FXML
+    private TableColumn<ReadOnlyPerson, Name> personsNameCol;
+    @FXML
+    private TableColumn<ReadOnlyPerson, Phone> personsPhoneCol;
+    @FXML
+    private TableColumn<ReadOnlyPerson, Email> personsEmailCol;
+    @FXML
+    private TableColumn<ReadOnlyPerson, Address> personsAddressCol;
+    @FXML
+    private TableColumn<ReadOnlyPerson, UniqueTagList> personsTagsCol;
 
     @FXML
     void onCommand(ActionEvent event) {

--- a/src/seedu/addressbook/ui/mainwindow.fxml
+++ b/src/seedu/addressbook/ui/mainwindow.fxml
@@ -2,6 +2,8 @@
 
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox stylesheets="@/seedu/addressbook/ui/DarkTheme.css" alignment="center" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
@@ -11,6 +13,20 @@
 
         <TextField fx:id="commandInput" onAction="#onCommand" VBox.vgrow="NEVER">
         </TextField>
+
+        <TableView fx:id="personsView" VBox.vgrow="ALWAYS">
+            <columnResizePolicy>
+                <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+            </columnResizePolicy>
+            <columns>
+                <TableColumn fx:id="personsIndexCol" text="#" sortable="false" maxWidth="640" />
+                <TableColumn fx:id="personsNameCol" text="Name" sortable="false" />
+                <TableColumn fx:id="personsPhoneCol" text="Phone" sortable="false" />
+                <TableColumn fx:id="personsEmailCol" text="Email" sortable="false" />
+                <TableColumn fx:id="personsAddressCol" text="Address" sortable="false" />
+                <TableColumn fx:id="personsTagsCol" text="Tags" sortable="false" />
+            </columns>
+        </TableView>
 
         <TextArea fx:id="outputConsole" editable="false" wrapText="true" VBox.vgrow="ALWAYS">
         </TextArea>

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -1,0 +1,29 @@
+package seedu.addressbook.logic;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.addressbook.data.AddressBook;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class AddressBookSessionTest {
+    private AddressBook addressBook;
+    private AddressBookSession addressBookSession;
+
+    @Before
+    public void setup() {
+        addressBook = new AddressBook();
+        addressBookSession = new AddressBookSession(addressBook);
+    }
+
+    @Test
+    public void constructor() {
+        // addressBook is empty
+        assertEquals(Collections.emptyList(), addressBook.getAllPersons().immutableListView());
+        // lastShownList is empty
+        assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
+    }
+}

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -118,4 +118,16 @@ public class AddressBookSessionTest {
         final Person bob = generatePersonWithName("Bob");
         assertFalse(addressBookSession.containsPerson(bob));
     }
+
+    @Test
+    public void clear_clearsAllPersons() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        final ReadOnlyPerson[] lastShownList = { bob };
+        addressBook.addPerson(bob);
+        addressBookSession.setLastShownList(Arrays.asList(lastShownList));
+        addressBookSession.clear();
+        assertEquals(Collections.emptyList(), addressBook.getAllPersons().immutableListView());
+        // lastShownList is untouched
+        assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
+    }
 }

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -102,8 +102,8 @@ public class AddressBookSessionTest {
         addressBookSession.removePerson(2);
         final ReadOnlyPerson[] expectedAB = { bill };
         assertEquals(Arrays.asList(expectedAB), addressBook.getAllPersons().immutableListView());
-        // lastShownList is untouched
-        assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
+        // bob is also removed from lastShownList
+        assertEquals(Arrays.asList(expectedAB), addressBookSession.getLastShownList());
     }
 
     @Test

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -80,4 +80,27 @@ public class AddressBookSessionTest {
         assertEquals(bill, addressBookSession.getPerson(1));
         assertEquals(bob, addressBookSession.getPerson(2));
     }
+
+    @Test
+    public void removePerson_invalidIndex_throwsIndexOutOfBoundsException() throws Exception {
+        thrown.expect(IndexOutOfBoundsException.class);
+        addressBookSession.removePerson(1);
+    }
+
+    @Test
+    public void removePerson_validIndex_removesCorrectPerson() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        final Person bill = generatePersonWithName("Bill");
+        addressBook.addPerson(bob);
+        addressBook.addPerson(bill);
+        // Note that the lastShownList reverses the order of persons, to test that
+        // addressBookSession uses the indexes of the lastShownList
+        ReadOnlyPerson[] lastShownList = { bill, bob };
+        addressBookSession.setLastShownList(Arrays.asList(lastShownList));
+        addressBookSession.removePerson(2);
+        final ReadOnlyPerson[] expectedAB = { bill };
+        assertEquals(Arrays.asList(expectedAB), addressBook.getAllPersons().immutableListView());
+        // lastShownList is untouched
+        assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
+    }
 }

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -60,7 +60,7 @@ public class AddressBookSessionTest {
         final ReadOnlyPerson[] expected = { toAdd };
         addressBookSession.addPerson(toAdd);
         assertEquals(Arrays.asList(expected), addressBook.getAllPersons().immutableListView());
-        assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
+        assertEquals(Arrays.asList(expected), addressBookSession.getLastShownList());
     }
 
     @Test

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.exception.IllegalValueException;
@@ -22,6 +24,9 @@ import static junit.framework.TestCase.assertEquals;
 public class AddressBookSessionTest {
     private AddressBook addressBook;
     private AddressBookSession addressBookSession;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -54,5 +59,25 @@ public class AddressBookSessionTest {
         addressBookSession.addPerson(toAdd);
         assertEquals(Arrays.asList(expected), addressBook.getAllPersons().immutableListView());
         assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
+    }
+
+    @Test
+    public void getPerson_invalidIndex_throwsIndexOutOfBoundsException() {
+        thrown.expect(IndexOutOfBoundsException.class);
+        addressBookSession.getPerson(1);
+    }
+
+    @Test
+    public void getPerson_validIndex_returnsCorrectPerson() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        final Person bill = generatePersonWithName("Bill");
+        addressBook.addPerson(bob);
+        addressBook.addPerson(bill);
+        // Note that the lastShownList reverses the order of persons, to test that
+        // addressBookSession uses the indexes of the lastShownList
+        ReadOnlyPerson[] lastShownList = { bill, bob };
+        addressBookSession.setLastShownList(Arrays.asList(lastShownList));
+        assertEquals(bill, addressBookSession.getPerson(1));
+        assertEquals(bob, addressBookSession.getPerson(2));
     }
 }

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -20,6 +20,8 @@ import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AddressBookSessionTest {
     private AddressBook addressBook;
@@ -102,5 +104,18 @@ public class AddressBookSessionTest {
         assertEquals(Arrays.asList(expectedAB), addressBook.getAllPersons().immutableListView());
         // lastShownList is untouched
         assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
+    }
+
+    @Test
+    public void containsPerson_doesContainsPerson_returnsTrue() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        addressBook.addPerson(bob);
+        assertTrue(addressBookSession.containsPerson(bob));
+    }
+
+    @Test
+    public void containsPerson_doesNotContainsPerson_returnsFalse() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        assertFalse(addressBookSession.containsPerson(bob));
     }
 }

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -1,11 +1,21 @@
 package seedu.addressbook.logic;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import seedu.addressbook.data.AddressBook;
+import seedu.addressbook.data.exception.IllegalValueException;
+import seedu.addressbook.data.person.Address;
+import seedu.addressbook.data.person.Email;
+import seedu.addressbook.data.person.Name;
+import seedu.addressbook.data.person.Person;
+import seedu.addressbook.data.person.Phone;
+import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.data.tag.Tag;
+import seedu.addressbook.data.tag.UniqueTagList;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -24,6 +34,25 @@ public class AddressBookSessionTest {
         // addressBook is empty
         assertEquals(Collections.emptyList(), addressBook.getAllPersons().immutableListView());
         // lastShownList is empty
+        assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
+    }
+
+    private static Person generatePersonWithName(String name) throws IllegalValueException {
+        return new Person(
+                new Name(name),
+                new Phone("1", false),
+                new Email("1@email", false),
+                new Address("House of 1", false),
+                new UniqueTagList(new Tag("tag"))
+        );
+    }
+
+    @Test
+    public void addPerson_callsAddPersonOnAddressBook() throws Exception {
+        final Person toAdd = generatePersonWithName("Bob");
+        final ReadOnlyPerson[] expected = { toAdd };
+        addressBookSession.addPerson(toAdd);
+        assertEquals(Arrays.asList(expected), addressBook.getAllPersons().immutableListView());
         assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
     }
 }

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -127,8 +127,8 @@ public class AddressBookSessionTest {
         addressBookSession.setLastShownList(Arrays.asList(lastShownList));
         addressBookSession.clear();
         assertEquals(Collections.emptyList(), addressBook.getAllPersons().immutableListView());
-        // lastShownList is untouched
-        assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
+        // lastShownList is also cleared
+        assertEquals(Collections.emptyList(), addressBookSession.getLastShownList());
     }
 
     @Test

--- a/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
+++ b/test/java/seedu/addressbook/logic/AddressBookSessionTest.java
@@ -130,4 +130,26 @@ public class AddressBookSessionTest {
         // lastShownList is untouched
         assertEquals(Arrays.asList(lastShownList), addressBookSession.getLastShownList());
     }
+
+    @Test
+    public void setFilter_withPredicate_filtersLastShownList() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        final Person bill = generatePersonWithName("Bill");
+        addressBook.addPerson(bob);
+        addressBook.addPerson(bill);
+        addressBookSession.setFilter(person -> person.getName().fullName.equals("Bob"));
+        ReadOnlyPerson[] expected = { bob };
+        assertEquals(Arrays.asList(expected), addressBookSession.getLastShownList());
+    }
+
+    @Test
+    public void setFilter_null_showsAll() throws Exception {
+        final Person bob = generatePersonWithName("Bob");
+        final Person bill = generatePersonWithName("Bill");
+        addressBook.addPerson(bob);
+        addressBook.addPerson(bill);
+        addressBookSession.setFilter(null);
+        ReadOnlyPerson[] expected = { bob, bill };
+        assertEquals(Arrays.asList(expected), addressBookSession.getLastShownList());
+    }
 }

--- a/test/java/seedu/addressbook/logic/LogicTest.java
+++ b/test/java/seedu/addressbook/logic/LogicTest.java
@@ -353,9 +353,11 @@ public class LogicTest {
         Person p3 = helper.generatePerson(3, true);
 
         List<Person> threePersons = helper.generatePersonList(p1, p2, p3);
+        List<Person> twoPersons = new ArrayList<>(threePersons);
 
         AddressBook expectedAB = helper.generateAddressBook(threePersons);
         expectedAB.removePerson(p2);
+        twoPersons.remove(1);
 
 
         helper.addToAddressBook(addressBook, threePersons);
@@ -365,7 +367,7 @@ public class LogicTest {
                                 String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, p2),
                                 expectedAB,
                                 false,
-                                threePersons);
+                                twoPersons);
     }
 
     @Test

--- a/test/java/seedu/addressbook/logic/LogicTest.java
+++ b/test/java/seedu/addressbook/logic/LogicTest.java
@@ -45,7 +45,7 @@ public class LogicTest {
         //Constructor is called in the setup() method which executes before every test, no need to call it here again.
 
         //Confirm the last shown list is empty
-        assertEquals(Collections.emptyList(), logic.getLastShownList());
+        assertEquals(Collections.emptyList(), logic.getAddressBookSession().getLastShownList());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class LogicTest {
 
         //Confirm the state of data is as expected
         assertEquals(expectedAddressBook, addressBook);
-        assertEquals(lastShownList, logic.getLastShownList());
+        assertEquals(lastShownList, logic.getAddressBookSession().getLastShownList());
         assertEquals(addressBook, saveFile.load());
     }
 
@@ -223,7 +223,7 @@ public class LogicTest {
         TestDataHelper helper = new TestDataHelper();
         List<Person> lastShownList = helper.generatePersonList(false, true);
 
-        logic.setLastShownList(lastShownList);
+        logic.getAddressBookSession().setLastShownList(lastShownList);
 
         assertCommandBehavior(commandWord + " -1", expectedMessage, AddressBook.empty(), false, lastShownList);
         assertCommandBehavior(commandWord + " 0", expectedMessage, AddressBook.empty(), false, lastShownList);
@@ -241,7 +241,7 @@ public class LogicTest {
         AddressBook expectedAB = helper.generateAddressBook(lastShownList);
         helper.addToAddressBook(addressBook, lastShownList);
 
-        logic.setLastShownList(lastShownList);
+        logic.getAddressBookSession().setLastShownList(lastShownList);
 
         assertCommandBehavior("view 1",
                               String.format(ViewCommand.MESSAGE_VIEW_PERSON_DETAILS, p1.getAsTextHidePrivate()),
@@ -267,7 +267,7 @@ public class LogicTest {
         expectedAB.addPerson(p2);
 
         addressBook.addPerson(p2);
-        logic.setLastShownList(lastShownList);
+        logic.getAddressBookSession().setLastShownList(lastShownList);
 
         assertCommandBehavior("view 1",
                               Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK,
@@ -297,7 +297,7 @@ public class LogicTest {
         AddressBook expectedAB = helper.generateAddressBook(lastShownList);
         helper.addToAddressBook(addressBook, lastShownList);
 
-        logic.setLastShownList(lastShownList);
+        logic.getAddressBookSession().setLastShownList(lastShownList);
 
         assertCommandBehavior("viewall 1",
                             String.format(ViewCommand.MESSAGE_VIEW_PERSON_DETAILS, p1.getAsTextShowAll()),
@@ -323,7 +323,7 @@ public class LogicTest {
         expectedAB.addPerson(p1);
 
         addressBook.addPerson(p1);
-        logic.setLastShownList(lastShownList);
+        logic.getAddressBookSession().setLastShownList(lastShownList);
 
         assertCommandBehavior("viewall 2",
                                 Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK,
@@ -358,7 +358,7 @@ public class LogicTest {
 
 
         helper.addToAddressBook(addressBook, threePersons);
-        logic.setLastShownList(threePersons);
+        logic.getAddressBookSession().setLastShownList(threePersons);
 
         assertCommandBehavior("delete 2",
                                 String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, p2),
@@ -382,7 +382,7 @@ public class LogicTest {
 
         helper.addToAddressBook(addressBook, threePersons);
         addressBook.removePerson(p2);
-        logic.setLastShownList(threePersons);
+        logic.getAddressBookSession().setLastShownList(threePersons);
 
         assertCommandBehavior("delete 2",
                                 Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK,

--- a/test/java/seedu/addressbook/logic/LogicTest.java
+++ b/test/java/seedu/addressbook/logic/LogicTest.java
@@ -153,13 +153,14 @@ public class LogicTest {
         Person toBeAdded = helper.adam();
         AddressBook expectedAB = new AddressBook();
         expectedAB.addPerson(toBeAdded);
+        final List<ReadOnlyPerson> expectedList = expectedAB.getAllPersons().immutableListView();
 
         // execute command and verify result
         assertCommandBehavior(helper.generateAddCommand(toBeAdded),
                               String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
                               expectedAB,
                               false,
-                              Collections.emptyList());
+                              expectedList);
 
     }
 


### PR DESCRIPTION
Presently, commands such as "delete" or "view" operate on a "lastShownList index", which is based on the list printed on the screen when the user last ran "list" or "find". This "lastShownList" is, however, erased from the user interface whenever users run another command, which is not very useful as users need to refer to this lastShownList to get the index to perform operations.

Furthermore, operations on the address book are not reflected in the lastShownList. For example, if a user deletes a person, the person still remains in the lastShownList. This could potentially confuse users who may think that the person is not deleted.

To make it easier to visualize operations on the address book, this PR adds a TableView to the MainWindow UI which will always display the lastShownList. Furthermore, it also ensures that all operations on the address book are reflected in the lastShownList as well.

This PR is quite large, but can be roughly broken down into a few parts:
## Prologue
- [1/17] [Fix code style errors](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/655063cefb1874b63bfaaf89469f3df92127aab9)
- [2/17] [commands: push down targetIndex](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/1ca980bf760244e383b6b891aac590050f722464)
- [3/17] [UniqueTagList: implement toString()](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/41d15ceec7fca8811b52c54d6d867a290ed5167c)

Some preparatory work.
## Part 1
- [4/17] [logic: extract AddressBookSession class](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/de6a4e94ed41278ff5e99573b140b97b4fec2f9b)
- [5/17] [commands: extract addPerson() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/cb7e20ba1019cc31c57691891ae25c3b80adde2d)
- [6/17] [commands: extract getPerson() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/90215ce893abc16c323551b78e517f422d2de67f)
- [7/17] [commands: extract removePerson() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/8f78f939864939c84972109c695261e349b438f5)
- [8/17] [commands: extract containsPerson() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/4f2a2179427f6e2644aec46a7658d7da6d108b4c)
- [9/17] [commands: extract clear() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/cc12d2e759b2bdc9f0b2efaed8a460ad4d365afb)
- [10/17] [commands: extract {get,set}Filter() into AddressBookSession](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/d5f04c412217aae7c1959632dc5c680fa868b898)
- [11/17] [Command: remove unused members](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/0866a7c7774cd359fff9dd9ffa9089a866ded682)
- [12/17] [Logic: don't overwrite lastShownList with CommandResult](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/a519b23d0df4f3a68751e0509792af3a893ccd05)

This is the first part. We extract an AddressBookSession class to manage the AddressBook and lastShownList, and make sure that all operations on the address book are routed through it. This sets things up for the third part where we will make sure that the lastShownList is synced with changes to the address book.
## Part 2
- [13/17] [AddressBookSession: make lastShownList an ObservableList](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/e6c32b561441d8206a9453ffd68e4c99f9d9cb7d)
- [14/17] [ui: display lastShownList as TableView](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/7ce7d59299495b9c19992ecc08621bd9128d0ff9)

This is the second part. We modify the user interface, adding a TableView which displays the lastShownList at all times.
## Part 3
- [15/17] [AddressBookSession.clear(): clear lastShownList as well](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/ee4e3d602de367a51a80dc1364a38dfee4048351)
- [16/17] [AddressBookSession.addPerson(): display added person in lastShownList](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/145448fc8f08d3252f8ea654111ab8a1a9bc2e48)
- [17/17] [AddressBookSession.removePerson(): update lastShownList as well](https://github.com/CS2103AUG2016-T11-C4/addressbook-level3/pull/3/commits/6f0214f3e94ebe7818335b05141060f8dd235def)

And in the final part, we add code to ensure that the lastShownList is synchronized with operations on the address book (clear, add, delete).

The final UI looks like this:

![featuresscreen](https://cloud.githubusercontent.com/assets/109479/18680402/22e5c674-7f96-11e6-975b-72e5d82208e2.png)
